### PR TITLE
履歴が1Pしか無い場合にぬるぽエラーが起きてしまう事象の修正

### DIFF
--- a/dlst.js
+++ b/dlst.js
@@ -12,7 +12,10 @@ for(var i=1;i<=lastPage;i++){
     var doc = new DOMParser().parseFromString(fetchUrl(dlurl+i),"text/html");
     if(i==1){
         console.log(`取得中 ${i}ページ目`);
-        lastPage = parseInt(doc.querySelector(".page_no ul li:last-child a").dataset.value);
+        var lastPageElm = doc.querySelector(".page_no ul li:last-child a");
+        if(lastPageElm){
+        lastPage = parseInt(lastPageElm.dataset.value);
+        }
     }else{
         console.log(`取得中 ${i}/${lastPage}ページ目`);
     }


### PR DESCRIPTION
だれかさんねっと様

■背景
お疲れさまです。
お友達とDLSiteの話で盛り上がった際にこちらのツールを使わせていただいたのですが、
バグが有りましたので、PRを上げさせていただきます。

■バグ内容
内容は表題の通りです。

履歴が2P以上ある友人に確認してもらったところ、
2P以上だと最後へのページリンクが有り、
本ツールではそちらの要素を取得し、取得中メッセージの最後のページとして表示されているようです。

履歴が1Pしかない場合、上記要素が取得できないことで、以下部分でぬるぽエラーが起きていました。
`doc.querySelector(".page_no ul li:last-child a").dataset`

■修正内容
lastPageを設定する直前で、まずエレメント内容を取得するようにしました。
エレメントの中身が存在する（nullやundefinedではない）場合に、
lastPageの値を更新するように修正しました。
if文に入らなければ初期値に1が入っているため、そちらも問題なく動きます。

以上です。
念の為、だれかさんねっと様の環境でもご確認いただければと存じます。